### PR TITLE
Generate Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,39 @@
 Basic slim api project and generator
 
 ![travis-ci status](https://travis-ci.org/gabriel403/slim-api.svg)
+
+Status
+==
+pre-alpha, init and create models is mostly complete, controllers, migrations and 'scaffold' is still to do, develop relations in model migrations.
+
+What?
+==
+A simple generator for producing simplified controllers/models and migrations, using Slim, Phinx and eloquent. It should be relatively simple to replace the controller|model template, and use something other than Phinx for migration.
+
+Why?
+==
+I wanted to be able to create API end points as easily as possible, and I love the simplicity of Slim, and after a sordid time with RoR this seemed like a fun thing to do!
+
+How?
+==
+Basic useage is simple, we first have to initiate the project, this creates a default skeleton for the project and initiates the phinx configuration.
+
+```
+slimapi init <project name> [location]
+```
+
+Location defaults to the cwd if not specified.
+
+When can then generate a model, this creates a migration and a simple model class.
+
+```
+slimapi generate model <model name> <model definitions>
+```
+
+Model definitions are a space seperated list of column definitions, of the form `name:type:limit:null:unique`, so
+
+```
+slimapi generate model Foo bar:integer baz:string:128:false bazbar:string:128::true
+```
+
+Would create a migration of 3 columns, baz would have a character limit and can't be null, bazbar would have a character limit and must be unique.

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6e590c9769360acc9154b557ea85ce57",
+    "hash": "bbdd3016aee08e2de1cb8786321e0db6",
     "packages": [
         {
             "name": "pimple/pimple",
@@ -120,12 +120,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Config.git",
-                "reference": "e5cbbc91949b4bbd3ea147ace3aae1aaee4843e7"
+                "reference": "3f495530550377a55c0cced5ddf8f58cfcd9ce5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Config/zipball/e5cbbc91949b4bbd3ea147ace3aae1aaee4843e7",
-                "reference": "e5cbbc91949b4bbd3ea147ace3aae1aaee4843e7",
+                "url": "https://api.github.com/repos/symfony/Config/zipball/3f495530550377a55c0cced5ddf8f58cfcd9ce5b",
+                "reference": "3f495530550377a55c0cced5ddf8f58cfcd9ce5b",
                 "shasum": ""
             },
             "require": {
@@ -162,7 +162,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-01 09:43:59"
+            "time": "2015-08-03 08:27:53"
         },
         {
             "name": "symfony/console",
@@ -170,12 +170,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/Console.git",
-                "reference": "a651989dc0ee7cb4fc850bfe4a8d981a348178aa"
+                "reference": "eb0fcf6f58054ac9d07539451e27aa4e17aebfe0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Console/zipball/a651989dc0ee7cb4fc850bfe4a8d981a348178aa",
-                "reference": "a651989dc0ee7cb4fc850bfe4a8d981a348178aa",
+                "url": "https://api.github.com/repos/symfony/Console/zipball/eb0fcf6f58054ac9d07539451e27aa4e17aebfe0",
+                "reference": "eb0fcf6f58054ac9d07539451e27aa4e17aebfe0",
                 "shasum": ""
             },
             "require": {
@@ -219,7 +219,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-08-01 11:59:20"
+            "time": "2015-08-04 15:59:05"
         },
         {
             "name": "symfony/filesystem",
@@ -476,12 +476,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "5700f75b23b0dd3495c0f495fe33a5e6717ee160"
+                "reference": "80da5500014051b9e70740f183c5e5586f38f977"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/5700f75b23b0dd3495c0f495fe33a5e6717ee160",
-                "reference": "5700f75b23b0dd3495c0f495fe33a5e6717ee160",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/80da5500014051b9e70740f183c5e5586f38f977",
+                "reference": "80da5500014051b9e70740f183c5e5586f38f977",
                 "shasum": ""
             },
             "require": {
@@ -495,7 +495,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.5.x-dev"
                 }
             },
             "autoload": {
@@ -528,7 +528,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2015-06-30 10:26:46"
+            "time": "2015-08-13 10:25:47"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -536,12 +536,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f41108eb9d8282cad3274e87a6b1b3478d9f8ce0"
+                "reference": "751653e81e3fcbddbe026f36e6e16fafd0a19f46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f41108eb9d8282cad3274e87a6b1b3478d9f8ce0",
-                "reference": "f41108eb9d8282cad3274e87a6b1b3478d9f8ce0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/751653e81e3fcbddbe026f36e6e16fafd0a19f46",
+                "reference": "751653e81e3fcbddbe026f36e6e16fafd0a19f46",
                 "shasum": ""
             },
             "require": {
@@ -549,7 +549,7 @@
                 "phpunit/php-file-iterator": "~1.3",
                 "phpunit/php-text-template": "~1.2",
                 "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.1",
+                "sebastian/environment": "^1.3.2",
                 "sebastian/version": "~1.0"
             },
             "require-dev": {
@@ -590,7 +590,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-08-02 10:50:04"
+            "time": "2015-08-17 07:51:01"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -727,12 +727,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "7a9b0969488c3c54fd62b4d504b3ec758fd005d9"
+                "reference": "92d472f7ac0cd45b7f6d66cb807646432cf89f5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/7a9b0969488c3c54fd62b4d504b3ec758fd005d9",
-                "reference": "7a9b0969488c3c54fd62b4d504b3ec758fd005d9",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/92d472f7ac0cd45b7f6d66cb807646432cf89f5d",
+                "reference": "92d472f7ac0cd45b7f6d66cb807646432cf89f5d",
                 "shasum": ""
             },
             "require": {
@@ -768,7 +768,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-06-19 03:43:16"
+            "time": "2015-08-18 15:47:59"
         },
         {
             "name": "phpunit/phpunit",
@@ -776,12 +776,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "0fe5ed323f0017624a65746153ae3fd69c308c1b"
+                "reference": "650f482841ac845c165e47758617e773e471bbe0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0fe5ed323f0017624a65746153ae3fd69c308c1b",
-                "reference": "0fe5ed323f0017624a65746153ae3fd69c308c1b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/650f482841ac845c165e47758617e773e471bbe0",
+                "reference": "650f482841ac845c165e47758617e773e471bbe0",
                 "shasum": ""
             },
             "require": {
@@ -840,7 +840,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-08-02 08:24:28"
+            "time": "2015-08-18 03:58:29"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -848,12 +848,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ca2e42cad8446a05691cc4327b7ce3ed45bfdb11"
+                "reference": "dccd8011934fba6fb77c7182c74926ad58c9ecd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ca2e42cad8446a05691cc4327b7ce3ed45bfdb11",
-                "reference": "ca2e42cad8446a05691cc4327b7ce3ed45bfdb11",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/dccd8011934fba6fb77c7182c74926ad58c9ecd1",
+                "reference": "dccd8011934fba6fb77c7182c74926ad58c9ecd1",
                 "shasum": ""
             },
             "require": {
@@ -896,7 +896,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-08-02 07:29:52"
+            "time": "2015-08-09 04:15:55"
         },
         {
             "name": "sebastian/comparator",
@@ -1020,12 +1020,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "3e39374f4c9ec3757839e2952e7a68ac28941760"
+                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/3e39374f4c9ec3757839e2952e7a68ac28941760",
-                "reference": "3e39374f4c9ec3757839e2952e7a68ac28941760",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
                 "shasum": ""
             },
             "require": {
@@ -1062,7 +1062,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-08-02 04:41:00"
+            "time": "2015-08-03 06:14:51"
         },
         {
             "name": "sebastian/exporter",
@@ -1070,12 +1070,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "66fb20c9e1b3617651c3f66be7a1747479d96ba5"
+                "reference": "f88f8936517d54ae6d589166810877fb2015d0a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/66fb20c9e1b3617651c3f66be7a1747479d96ba5",
-                "reference": "66fb20c9e1b3617651c3f66be7a1747479d96ba5",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/f88f8936517d54ae6d589166810877fb2015d0a2",
+                "reference": "f88f8936517d54ae6d589166810877fb2015d0a2",
                 "shasum": ""
             },
             "require": {
@@ -1129,7 +1129,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-07-30 09:58:30"
+            "time": "2015-08-09 04:23:41"
         },
         {
             "name": "sebastian/global-state",

--- a/src/Command/GenerateCommand.php
+++ b/src/Command/GenerateCommand.php
@@ -1,0 +1,80 @@
+<?php
+namespace SlimApi\Command;
+
+use \Exception;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class GenerateCommand extends Command
+{
+    public function __construct($generatorFactory)
+    {
+        parent::__construct();
+        $this->generatorFactory = $generatorFactory;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('generate')
+            ->setAliases(['g'])
+            ->setDescription('Creates a default slim-api application.')
+            ->addArgument(
+                'type',
+                InputArgument::REQUIRED,
+                'What type of generator? [scaffold, controller, model].'
+            )
+            ->addArgument(
+                'name',
+                InputArgument::REQUIRED,
+                'Resultant resource name.'
+            )
+            ->addArgument(
+                'fields',
+                InputArgument::IS_ARRAY,
+                'What fields (if appropriate).'
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $type = $input->getArgument('type');
+        if (!in_array($type, ['scaffold', 'controller', 'model', 'migration'])) {
+            throw new Exception('Invalid type.');
+        }
+
+        $name    = ucfirst($input->getArgument('name'));
+        $pattern = '/^[A-Z][a-zA-Z0-9]*$/';
+        if (1 !== preg_match($pattern, $name)) {
+            throw new Exception('Invalid name.');
+        }
+
+        $fields = $input->getArgument('fields');
+        if (!is_array($fields)) {
+            throw new Exception('Invalid fields.');
+        }
+
+        if (false === is_file('composer.json')) {
+            throw new Exception('Commands must be run from root of project.');
+        }
+
+        $generator = $this->generatorFactory->fetch($type);
+        if (!$generator->validate($name, $fields)) {
+            throw new Exception('Fields not valid.');
+        }
+
+        try {
+            $generator->process($name, $fields);
+            $output->writeln('Generation completed.');
+        } catch (Exception $e) {
+            echo $e->getMessage();
+        }
+
+
+        return true;
+    }
+}

--- a/src/Database/PhinxMigration.php
+++ b/src/Database/PhinxMigration.php
@@ -1,0 +1,42 @@
+<?php
+namespace SlimApi\Database;
+
+use Phinx\Migration\CreationInterface;
+
+class PhinxMigration implements CreationInterface
+{
+    public static $commands = [];
+    private $template = <<<'EOT'
+<?php
+
+use $useClassName;
+
+class $className extends $baseClassName
+{
+
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
+     */
+    public function change()
+    {
+        $commands
+    }
+}
+EOT;
+
+    public function getMigrationTemplate() {
+        $template = $this->template;
+        $template = strtr($template, ['$commands' => implode(PHP_EOL.'        ', static::$commands)]);
+        return $template;
+    }
+
+    public function postMigrationCreation($migrationFilename, $className, $baseClassName) {
+
+    }
+
+}

--- a/src/Factory/GeneratorFactory.php
+++ b/src/Factory/GeneratorFactory.php
@@ -1,0 +1,21 @@
+<?php
+namespace SlimApi\Factory;
+
+class GeneratorFactory
+{
+    public function __construct($generators)
+    {
+        $this->generators = $generators;
+    }
+
+    public function fetch($type)
+    {
+        $generator = false;
+        switch ($type) {
+            case 'model':
+                $generator = $this->generators['model'];
+                break;
+        }
+        return $generator;
+    }
+}

--- a/src/Generator/GeneratorInterface.php
+++ b/src/Generator/GeneratorInterface.php
@@ -1,0 +1,8 @@
+<?php
+namespace SlimApi\Generator;
+
+interface GeneratorInterface
+{
+    public function validate($name, $fields);
+    public function process($name, $fields);
+}

--- a/src/Generator/ModelGenerator.php
+++ b/src/Generator/ModelGenerator.php
@@ -1,0 +1,55 @@
+<?php
+namespace SlimApi\Generator;
+
+class ModelGenerator implements GeneratorInterface
+{
+    public function __construct($migrationService, $modelService)
+    {
+        $this->migrationService = $migrationService;
+        $this->modelService     = $modelService;
+    }
+
+    public function validate($name, $fields)
+    {
+        if ($this->modelExists($name)) {
+            return false;
+        }
+        return true;
+    }
+
+    public function process($name, $fields)
+    {
+        $this->processCreateMigration($name, $fields);
+        $this->processCreateModel($name, $fields);
+    }
+
+    private function processCreateMigration($name, $fields)
+    {
+        $this->migrationService->addMigrationCommand('create', ucfirst($name));
+
+        // name:type:limit:null:unique
+        foreach ($fields as $fieldDefinition) {
+            $fieldDefinition = explode(':', $fieldDefinition);
+            $fieldDefinition = array_map(function($value) {
+                return (strlen($value) === 0 ? NULL : $value);
+            }, $fieldDefinition);
+            $this->migrationService->addMigrationCommand('addColumn', ...$fieldDefinition);
+        }
+
+        $this->migrationService->addMigrationCommand('finalise');
+        $this->migrationService->create($name);
+    }
+
+    private function processCreateModel($name)
+    {
+        $this->modelService->create($name);
+    }
+
+    private function modelExists($name)
+    {
+        // cwd should also be namespace
+        // perhaps we could also parse the composer.json for
+        // ['autoload']['psr-4'] $key?
+        return is_file('src/Model/'.$name.'.php');
+    }
+}

--- a/src/Model/EloquentModelService.php
+++ b/src/Model/EloquentModelService.php
@@ -1,0 +1,18 @@
+<?php
+namespace SlimApi\Model;
+
+class EloquentModelService implements ModelInterface
+{
+    public function __construct($modelTemplate, $namespace) {
+        $this->modelTemplate = $modelTemplate;
+        $this->namespace     = $namespace;
+    }
+
+    public function create($name)
+    {
+        $name    = ucfirst($name);
+        $content = strtr($this->modelTemplate, ['$name' => $name, '$namespace' => $this->namespace]);
+
+        return file_put_contents('src/Model/'.$name.'.php', $content);
+    }
+}

--- a/src/Model/ModelInterface.php
+++ b/src/Model/ModelInterface.php
@@ -1,0 +1,8 @@
+<?php
+namespace SlimApi\Model;
+
+interface ModelInterface
+{
+    public function __construct($modelTemplate, $namespace);
+    public function create($name);
+}

--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -191,9 +191,18 @@ $container['services.database'] = function($container) {
     return new SlimApi\Database\PhinxService($container['phinxApplication']);
 };
 
+$container['factory.generator'] = function($container) {
+    return new SlimApi\Factory\GeneratorFactory(['model' => new SlimApi\Generator\ModelGenerator($container['services.database'], $container['services.model'])]);
+};
+
+$container['commands.generate'] = function($container) {
+    return new SlimApi\Command\GenerateCommand($container['factory.generator']);
+};
+
 $container['commands'] = function ($container) {
     return [
-        'init' => $container['commands.init'],
+        'init'     => $container['commands.init'],
+        'generate' => $container['commands.generate'],
     ];
 };
 

--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -1,6 +1,28 @@
 <?php
 $container = new Pimple\Container;
 
+$container['namespace.root'] = function($container) {
+    // alternativly load composer.json?
+    return ucfirst(basename(getcwd()));
+};
+
+$container['model.structure'] = function($container) {
+    return <<<'EOT'
+<?php
+namespace $namespace\Model;
+
+use \Illuminate\Database\Eloquent\Model;
+
+class $name extends Model
+{
+}
+EOT;
+};
+
+$container['services.model'] = function($container) {
+    return new \SlimApi\Model\EloquentModelService($container['model.structure'], $container['namespace.root']);
+};
+
 $container['services.skeleton.structure'] = function($container) {
     // I thought long and hard about to decalre dependencies
     // should there be one for each type? controllers, services, models?
@@ -70,9 +92,11 @@ EOT;
     $composer = <<<'EOT'
 {
     "require": {
-        "php"                 : "^5.6",
-        "gabriel403/slim-api" : "*@beta",
-        "slim/slim"           : "3.*@beta"
+        "php": "^5.6",
+        "gabriel403/slim-api": "*@beta",
+        "slim/slim": "3.*@beta",
+        "robmorgan/phinx": "0.*",
+        "illuminate/database": "5.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0@dev"

--- a/src/dependencies.php
+++ b/src/dependencies.php
@@ -78,10 +78,10 @@ EOT;
         "phpunit/phpunit": "^5.0@dev"
     },
     "autoload": {
-        "psr-4": {"{$name}\\": "src/"}
+        "psr-4": {"$name\\": "src/"}
     },
     "autoload-dev": {
-        "psr-4": {"{$name}Test\\": "tests/phpunit/"}
+        "psr-4": {"$nameTest\\": "tests/phpunit/"}
     }
 }
 EOT;
@@ -126,6 +126,7 @@ EOT;
 
     return [
         'config' => [],
+        'migrations' => [],
         'src' => [
             'Controller'       => [
                 '.gitkeep' => '',

--- a/tests/phpunit/Command/GenerateCommandTest.php
+++ b/tests/phpunit/Command/GenerateCommandTest.php
@@ -1,0 +1,162 @@
+<?php
+namespace SlimApiTest\Command;
+
+use SlimApi\Command\GenerateCommand;
+use SlimApiTest\Mock\ModelGeneratorMock;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use org\bovigo\vfs\vfsStream;
+
+class MockModelGeneratorMock{public function validate() {return false;}}
+class MockModelGeneratorMock2{public function validate() {return true;} public function process() {throw new \Exception;}}
+
+class GenerateCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected $tester;
+    protected $command;
+
+    protected function setUp()
+    {
+        $generatorFactory = $this->getMockBuilder('SlimApi\Factory\GeneratorFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $generatorFactory->method('fetch')
+            ->willReturn(new ModelGeneratorMock);
+
+        $application = new Application('SlimApi', '@package_version@');
+        $application->add(new GenerateCommand($generatorFactory));
+        $this->command = $application->find('generate');
+        $this->tester  = new CommandTester($this->command);
+    }
+
+    public function testNotEnoughArgs1()
+    {
+        $this->setExpectedException('Exception', 'Not enough arguments.');
+        $this->tester->execute([
+            'command' => $this->command->getName(),
+            'type'    => '5foo'
+        ]);
+    }
+
+    public function testNotEnoughArgs2()
+    {
+        $this->setExpectedException('Exception', 'Not enough arguments.');
+        $this->tester->execute([
+            'command' => $this->command->getName(),
+            'name'    => 'bar'
+        ]);
+    }
+
+    public function testInvalidType()
+    {
+        $this->setExpectedException('Exception', 'Invalid type.');
+        $this->tester->execute([
+            'command' => $this->command->getName(),
+            'type'    => '5foo',
+            'name'    => 'bar'
+        ]);
+    }
+
+    public function testInvalidName()
+    {
+        $this->setExpectedException('Exception', 'Invalid name.');
+        $this->tester->execute([
+            'command' => $this->command->getName(),
+            'type'    => 'scaffold',
+            'name'    => '5bar'
+        ]);
+    }
+
+    public function testInvalidFields()
+    {
+        $this->setExpectedException('Exception', 'Invalid fields.');
+        $this->tester->execute([
+            'command' => $this->command->getName(),
+            'type'    => 'scaffold',
+            'name'    => 'bar',
+            'fields'  => 'some'
+        ]);
+    }
+
+    public function testRunFromInvalidPath()
+    {
+        $composerContent = '{"autoload":{"psr-4": {"Project0\\\": "src/"}}}';
+        chdir(__DIR__.'/../output');
+        if (file_exists('project0')) {
+            exec('rm -rf project0');
+        }
+        mkdir('project0');
+        mkdir('project0/src');
+        mkdir('project0/src/Model');
+        file_put_contents('project0/composer.json', $composerContent);
+        chdir('project0/src/Model');
+        $this->setExpectedException('Exception', 'Commands must be run from root of project.');
+        $this->tester->execute([
+            'command' => $this->command->getName(),
+            'type'    => 'model',
+            'name'    => 'bar'
+        ]);
+    }
+
+    public function testModelExists()
+    {
+        $generatorFactory = $this->getMockBuilder('SlimApi\Factory\GeneratorFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $generatorFactory->method('fetch')
+            ->willReturn(new MockModelGeneratorMock);
+
+        $application = new Application('SlimApi', '@package_version@');
+        $application->add(new GenerateCommand($generatorFactory));
+        $tester  = new CommandTester($application->find('generate'));
+
+        $composerContent = '{"autoload":{"psr-4": {"Project0\\\": "src/"}}}';
+        $modelContent = '<?php namespace Project1\Model; class Test {}';
+        chdir(__DIR__.'/../output');
+        if (file_exists('project0')) {
+            exec('rm -rf project0');
+        }
+        mkdir('project0');
+        mkdir('project0/src');
+        mkdir('project0/src/Model');
+        file_put_contents('project0/composer.json', $composerContent);
+        file_put_contents('project0/src/Model/Bar.php', $modelContent);
+        chdir('project0');
+        $this->setExpectedException('Exception', 'Fields not valid.');
+        $tester->execute([
+            'command' => $this->command->getName(),
+            'type'    => 'model',
+            'name'    => 'bar'
+        ]);
+    }
+
+    public function testProcessException()
+    {
+        $generatorFactory = $this->getMockBuilder('SlimApi\Factory\GeneratorFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $generatorFactory->method('fetch')
+            ->willReturn(new MockModelGeneratorMock2);
+
+        $application = new Application('SlimApi', '@package_version@');
+        $application->add(new GenerateCommand($generatorFactory));
+        $tester  = new CommandTester($application->find('generate'));
+
+        $result = $tester->execute([
+            'command' => $this->command->getName(),
+            'type'    => 'model',
+            'name'    => 'baz'
+        ]);
+        $this->assertEquals(0, $result);
+    }
+
+    public function testSuccess()
+    {
+        $result = $this->tester->execute([
+            'command' => $this->command->getName(),
+            'type'    => 'model',
+            'name'    => 'baz'
+        ]);
+        $this->assertEquals(0, $result);
+    }
+}

--- a/tests/phpunit/Database/PhinxMigrationTest.php
+++ b/tests/phpunit/Database/PhinxMigrationTest.php
@@ -1,0 +1,45 @@
+<?php
+namespace SlimApiTest\Database;
+
+use SlimApi\Database\PhinxMigration;
+
+class PhinxMigrationTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected function setUp()
+    {
+        $this->phinxMigration = new PhinxMigration;
+    }
+
+    public function testGetMigrationTemplate()
+    {
+        PhinxMigration::$commands = ['$table = $this->table("Foo");',
+            '$table->addColumn("one", "integer");',
+            '$table->create();'];
+        $template = <<<'EOT'
+<?php
+
+use $useClassName;
+
+class $className extends $baseClassName
+{
+
+    /**
+     * Change Method.
+     *
+     * Write your reversible migrations using this method.
+     *
+     * More information on writing migrations is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-abstractmigration-class
+     */
+    public function change()
+    {
+        $table = $this->table("Foo");
+        $table->addColumn("one", "integer");
+        $table->create();
+    }
+}
+EOT;
+        $this->assertEquals($template, $this->phinxMigration->getMigrationTemplate());
+    }
+}

--- a/tests/phpunit/Database/PhinxServiceTest.php
+++ b/tests/phpunit/Database/PhinxServiceTest.php
@@ -1,0 +1,104 @@
+<?php
+namespace SlimApiTest\Database;
+
+use SlimApi\Database\PhinxService;
+use Symfony\Component\Console\Application;
+use org\bovigo\vfs\vfsStream;
+
+class PhinxApplicationMock {public function run(){return true;} public function find($name) { $class = '\Phinx\Console\Command\\'.ucfirst($name); return new $class; }}
+class PhinxServiceTest extends \PHPUnit_Framework_TestCase
+{
+
+    protected function setUp()
+    {
+        // $phinxApplicationMock = $this->getMockBuilder('Symfony\Component\Console\Application')
+        //     ->disableOriginalConstructor()
+        //     ->getMock();
+        // $phinxApplicationMock->method('run')
+        //     ->willReturn(true);
+        $phinxApplicationMock = $this->getMockBuilder('stdClass')
+            ->getMock();
+        $phinxApplicationMock->method('run')
+            ->willReturn(true);
+        $this->phinxService = new PhinxService($phinxApplicationMock);
+    }
+
+    public function testInvalidMigrationType()
+    {
+        $this->setExpectedException('Exception', 'Invalid migration type.');
+        $this->phinxService->addMigrationCommand('foo');
+    }
+
+    public function testCreateTable()
+    {
+        $this->phinxService->addMigrationCommand('create', 'test');
+        $this->assertEquals(1, count($this->phinxService->commands));
+        $this->assertEquals('$table = $this->table("test");', $this->phinxService->commands[0]);
+    }
+
+    public function testAddColumnIncorrectType()
+    {
+        $this->setExpectedException('Exception', 'Type not valid.');
+        $this->phinxService->addMigrationCommand('addColumn', 'test', 'int');
+    }
+
+    public function testAddColumnSimple()
+    {
+        $this->phinxService->addMigrationCommand('addColumn', 'test', 'integer');
+        $this->assertEquals(1, count($this->phinxService->commands));
+        $this->assertEquals('$table->addColumn("test", "integer");', $this->phinxService->commands[0]);
+    }
+
+    public function testAddColumnWithLimit()
+    {
+        $this->phinxService->addMigrationCommand('addColumn', 'test', 'integer', '30');
+        $this->assertEquals(1, count($this->phinxService->commands));
+        $this->assertEquals('$table->addColumn("test", "integer", ["limit" => 30]);', $this->phinxService->commands[0]);
+    }
+
+    public function testAddColumnWithNull()
+    {
+        $this->phinxService->addMigrationCommand('addColumn', 'test', 'integer', null, 'true');
+        $this->assertEquals(1, count($this->phinxService->commands));
+        $this->assertEquals('$table->addColumn("test", "integer", ["null" => true]);', $this->phinxService->commands[0]);
+    }
+
+    public function testAddColumnWithUnique()
+    {
+        $this->phinxService->addMigrationCommand('addColumn', 'test', 'integer', null, null, 'true');
+        $this->assertEquals(1, count($this->phinxService->commands));
+        $this->assertEquals('$table->addColumn("test", "integer", ["unique" => true]);', $this->phinxService->commands[0]);
+    }
+
+    public function testAddColumnWithEverything()
+    {
+        $this->phinxService->addMigrationCommand('addColumn', 'test', 'integer', '30', 'false', 'true');
+        $this->assertEquals(1, count($this->phinxService->commands));
+        $this->assertEquals('$table->addColumn("test", "integer", ["limit" => 30, "null" => false, "unique" => true]);', $this->phinxService->commands[0]);
+    }
+
+    public function testFinaliseTable()
+    {
+        $this->phinxService->addMigrationCommand('finalise');
+        $this->assertEquals(1, count($this->phinxService->commands));
+        $this->assertEquals('$table->create();', $this->phinxService->commands[0]);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testModelExists()
+    {
+        $phinxService = new PhinxService(new \Phinx\Console\PhinxApplication);
+
+        chdir(__DIR__.'/../output');
+        if (file_exists('project0')) {
+            exec('rm -rf project0');
+        }
+        mkdir('project0');
+
+        $this->assertFalse(is_file('project0/phinx.yml'));
+        $phinxService->init('project0/');
+        $this->assertTrue(is_file('project0/phinx.yml'));
+    }
+}

--- a/tests/phpunit/Factory/GeneratorFactoryTest.php
+++ b/tests/phpunit/Factory/GeneratorFactoryTest.php
@@ -1,0 +1,19 @@
+<?php
+namespace SlimApiTest\Factory;
+
+use SlimApi\Factory\GeneratorFactory;
+use SlimApiTest\Mock\ModelGeneratorMock;
+
+class GeneratorFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $this->generatorFactory = new GeneratorFactory(['model' => new ModelGeneratorMock]);
+    }
+
+    public function testReturnsModelGenerator()
+    {
+        $generator = $this->generatorFactory->fetch('model');
+        $this->assertInstanceOf('SlimApi\Generator\ModelGenerator', $generator);
+    }
+}

--- a/tests/phpunit/Generator/ModelGeneratorTest.php
+++ b/tests/phpunit/Generator/ModelGeneratorTest.php
@@ -1,0 +1,103 @@
+<?php
+namespace SlimApiTest\Generator;
+
+use SlimApi\Generator\ModelGenerator;
+use SlimApi\Database\PhinxService;
+use org\bovigo\vfs\vfsStream;
+
+class PhinxApplicationMock {public function run(){return true;} public function find($name) { $class = '\Phinx\Console\Command\\'.ucfirst($name); return new $class; }}
+class CommandMock {public function run(){return 0;}}
+class ModelServiceMock {public function create(){return true;}}
+class PhinxApplication2Mock {public function run(){return true;} public function find($name) { return new CommandMock; }}
+
+class ModelGeneratorTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        // $phinxApplicationMock = $this->getMockBuilder('stdClass')
+        //     ->disableOriginalConstructor()
+        //     ->getMock();
+        // $phinxApplicationMock->method('run')
+        //     ->willReturn(true);
+        // $phinxApplicationMock->run();
+        $this->modelGenerator = new ModelGenerator(new PhinxService(new PhinxApplication2Mock), new ModelServiceMock);
+    }
+
+    public function testModelExists()
+    {
+        $this->modelGenerator = new ModelGenerator(new PhinxService(new PhinxApplicationMock), new ModelServiceMock);
+        $composerContent = '{"autoload":{"psr-4": {"Project1\\\": "src/"}}}';
+        $modelContent = '<?php namespace Project1\Model; class Foo {}';
+        chdir(__DIR__.'/../output');
+        if (file_exists('project1')) {
+            exec('rm -rf project1');
+        }
+        mkdir('project1');
+        mkdir('project1/src');
+        mkdir('project1/src/Model');
+        file_put_contents('project1/composer.json', $composerContent);
+        file_put_contents('project1/src/Model/Foo.php', $modelContent);
+        chdir('project1/');
+
+        $this->assertFalse($this->modelGenerator->validate('Foo', []));
+    }
+
+    public function testModelNotExists()
+    {
+        $this->modelGenerator = new ModelGenerator(new PhinxService(new PhinxApplicationMock), new ModelServiceMock);
+        $composerContent = '{"autoload":{"psr-4": {"Project2\\\": "src/"}}}';
+        chdir(__DIR__.'/../output');
+        if (file_exists('project2')) {
+            exec('rm -rf project2');
+        }
+        mkdir('project2');
+        mkdir('project2/src');
+        mkdir('project2/src/Model');
+        file_put_contents('project2/composer.json', $composerContent);
+        chdir('project2/');
+
+        $this->assertTrue($this->modelGenerator->validate('Foo', []));
+    }
+
+    public function testSimpleProcess()
+    {
+        $expected = ['$table = $this->table("Foo");', '$table->addColumn("col1", "integer");', '$table->create();'];
+        $this->modelGenerator->process('Foo', ['col1:integer']);
+        $this->assertEquals($expected, $this->modelGenerator->migrationService->commands);
+    }
+
+    public function testLimitProcess()
+    {
+        $expected = ['$table = $this->table("Foo");', '$table->addColumn("col1", "integer", ["limit" => 30]);', '$table->create();'];
+        $this->modelGenerator->process('Foo', ['col1:integer:30']);
+        $this->assertEquals($expected, $this->modelGenerator->migrationService->commands);
+    }
+
+    public function testNullableProcess()
+    {
+        $expected = ['$table = $this->table("Foo");', '$table->addColumn("col1", "integer", ["null" => false]);', '$table->create();'];
+        $this->modelGenerator->process('Foo', ['col1:integer::false']);
+        $this->assertEquals($expected, $this->modelGenerator->migrationService->commands);
+    }
+
+    public function testUniqueProcess()
+    {
+        $expected = ['$table = $this->table("Foo");', '$table->addColumn("col1", "integer", ["unique" => true]);', '$table->create();'];
+        $this->modelGenerator->process('Foo', ['col1:integer:::true']);
+        $this->assertEquals($expected, $this->modelGenerator->migrationService->commands);
+    }
+
+    public function testLimitUniqueProcess()
+    {
+        $expected = ['$table = $this->table("Foo");', '$table->addColumn("col1", "integer", ["limit" => 30, "unique" => true]);', '$table->create();'];
+        $this->modelGenerator->process('Foo', ['col1:integer:30::true']);
+        $this->assertEquals($expected, $this->modelGenerator->migrationService->commands);
+    }
+
+    public function testAllProcess()
+    {
+        $expected = ['$table = $this->table("Foo");', '$table->addColumn("col1", "integer", ["limit" => 30, "null" => false, "unique" => true]);', '$table->create();'];
+        $this->modelGenerator->process('Foo', ['col1:integer:30:false:true']);
+        $this->assertEquals($expected, $this->modelGenerator->migrationService->commands);
+    }
+}

--- a/tests/phpunit/Mock/ModelGeneratorMock.php
+++ b/tests/phpunit/Mock/ModelGeneratorMock.php
@@ -1,0 +1,24 @@
+<?php
+namespace SlimApiTest\Mock;
+
+use SlimApi\Generator\ModelGenerator;
+use SlimApi\Command\GenerateCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class ModelGeneratorMock extends ModelGenerator
+{
+    public function __construct()
+    {
+    }
+
+    public function validate($name, $fields)
+    {
+        return true;
+    }
+
+    public function process($name, $fields)
+    {
+        return true;
+    }
+}

--- a/tests/phpunit/Model/EloquentModelServiceTest.php
+++ b/tests/phpunit/Model/EloquentModelServiceTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace SlimApiTest\Model;
+
+use \SlimApi\Model\EloquentModelService;
+
+class EloquentModelServiceTest extends \PHPUnit_Framework_TestCase
+{
+    protected function setUp()
+    {
+        $modelTemplate = <<<'EOT'
+<?php
+namespace $namespace\Model;
+
+use \Illuminate\Database\Eloquent\Model;
+
+class $name extends Model
+{
+}
+EOT;
+
+        $this->eloquentModelService = new EloquentModelService($modelTemplate, 'FooTest');
+
+        chdir(__DIR__.'/../output');
+        if (file_exists('project0')) {
+            exec('rm -rf project0');
+        }
+        mkdir('project0');
+        mkdir('project0/src');
+        mkdir('project0/src/Model');
+        chdir('project0/');
+    }
+
+    public function testCreate()
+    {
+        $modelStr =<<<'EOT'
+<?php
+namespace FooTest\Model;
+
+use \Illuminate\Database\Eloquent\Model;
+
+class Bar extends Model
+{
+}
+EOT;
+
+        $this->eloquentModelService->create('Bar');
+        $this->assertEquals($modelStr, file_get_contents('src/Model/Bar.php'));
+    }
+}


### PR DESCRIPTION
Enables the ability to generate migrations and models, hard coded to phinx/eloquent initially.

Uses the api command to generate migrations with simple columns

closes #2 
